### PR TITLE
Add devcontainer configuration for development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8"
   },
-  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y tmux && cd kanban-app && npm install && npm install -g @anthropic-ai/claude-code",
+  "postCreateCommand": "sudo locale-gen en_US.UTF-8 && sudo apt-get update && sudo apt-get install -y tmux && cd kanban-app && npm install && npm install -g @anthropic-ai/claude-code",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -24,5 +24,6 @@
         "esbenp.prettier-vscode"
       ]
     }
-  }
+  },
+  "remoteUser": "vscode"
 }


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/devcontainer.json` with all dependencies needed to run Antler
- Includes Go 1.23, Node.js LTS, and GitHub CLI
- Forwards ports 3000 (frontend) and 8083 (backend)
- Auto-installs npm dependencies on container creation

Closes #1

## Test plan
- [x] Open repository in a devcontainer (VS Code, GitHub Codespaces, or devcontainer CLI)
- [x] Verify Go, Node.js, and gh CLI are available
- [x] Run `./build.sh` and confirm both services start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)