### PR TITLE
Replace refresh button with icon-only spinner

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,13 +6,31 @@ import { useDataSource } from './hooks/useDataSource';
 import { useKanbanBoard } from './hooks/useKanbanBoard';
 import { Toggle } from './components/ui/toggle';
 
-function ActionButton({ onClick, children }: { onClick: () => void; children: ReactNode }) {
+function ActionButton({
+  onClick,
+  children,
+  isLoading = false,
+  disabled = false
+}: {
+  onClick: () => void;
+  children: ReactNode;
+  isLoading?: boolean;
+  disabled?: boolean;
+}) {
   return (
     <button
       onClick={onClick}
-      className="px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
+      disabled={disabled || isLoading}
+      className="px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
     >
-      {children}
+      {isLoading ? (
+        <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+      ) : (
+        children
+      )}
     </button>
   );
 }
@@ -41,22 +59,42 @@ function SetupGuide({ onRetry }: { onRetry: () => void }) {
 function Header({
   isMock,
   setDataSource,
-  onRefresh
+  onRefresh,
+  isRefreshing
 }: {
   isMock: boolean;
   setDataSource: (source: "mock" | "github") => void;
   onRefresh: () => void;
+  isRefreshing: boolean;
 }) {
   return (
-    <div className="p-6 flex items-center justify-between shrink-0">
-      <Toggle
-        pressed={isMock}
-        onPressedChange={(pressed) => setDataSource(pressed ? "mock" : "github")}
-        className={isMock ? "text-amber-600" : "text-green-600"}
-      >
-        {isMock ? "Mock Data" : "GitHub"}
-      </Toggle>
-      <ActionButton onClick={onRefresh}>Refresh</ActionButton>
+    <div className="px-6 pt-6 pb-2 shrink-0">
+      {/* Match board width: 4 columns × 18rem + 3 gaps × 1rem = 75rem, but allow shrinking */}
+      <div className="flex items-center justify-between w-full max-w-[calc(4*18rem+3*1rem)]">
+        <Toggle
+          pressed={isMock}
+          onPressedChange={(pressed) => setDataSource(pressed ? "mock" : "github")}
+          className={isMock ? "text-amber-600" : "text-green-600"}
+        >
+          {isMock ? "Mock Data" : "GitHub"}
+        </Toggle>
+        <button
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="p-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="Refresh"
+        >
+          <svg
+            className={`h-5 w-5 ${isRefreshing ? 'animate-spin' : ''}`}
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+        </button>
+      </div>
     </div>
   );
 }
@@ -96,9 +134,6 @@ export default function App() {
             <ActionButton onClick={refresh}>Retry</ActionButton>
           </div>
         )}
-        {isRefreshing && (
-          <div className="mx-6 mb-4 text-gray-500 text-sm shrink-0">Refreshing...</div>
-        )}
         <KanbanBoard cards={cards} onCardStatusChange={handleCardStatusChange} />
       </>
     );
@@ -107,7 +142,7 @@ export default function App() {
   return (
     <DotBackground>
       <div className="h-screen flex flex-col overflow-hidden">
-        <Header isMock={isMock} setDataSource={setDataSource} onRefresh={refresh} />
+        <Header isMock={isMock} setDataSource={setDataSource} onRefresh={refresh} isRefreshing={isRefreshing} />
         {renderContent()}
       </div>
     </DotBackground>


### PR DESCRIPTION
## Summary
- Replace text "Refresh" button with an icon-only button showing a spinner SVG
- Spinner animates during refresh, stays static otherwise
- Align header controls with Kanban board columns for visual consistency
- Make header responsive so refresh button remains visible on smaller windows

Closes #19

## Test plan
- [x] Click refresh button and verify icon spins while loading
- [x] Resize window to small size and verify refresh button stays visible
- [x] Verify header aligns with the right edge of the Done column

🤖 Generated with [Claude Code](https://claude.com/claude-code)