### PR TITLE
Add responsive layout for mobile devices

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,9 +74,8 @@ function Header({
   isRefreshing: boolean;
 }) {
   return (
-    <div className="px-6 pt-6 pb-2 shrink-0">
-      {/* Match board width: 4 columns × 18rem + 3 gaps × 1rem = 75rem, but allow shrinking */}
-      <div className="flex items-center justify-between w-full max-w-[calc(4*18rem+3*1rem)]">
+    <div className="px-6 pt-6 pb-2 shrink-0 flex justify-center">
+      <div className="flex items-center justify-between w-full md:max-w-[calc(4*18rem+3*1rem)]">
         <div className="flex items-center gap-4">
           <Toggle
             pressed={isMock}

--- a/src/renderer/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/renderer/components/KanbanBoard/KanbanBoard.tsx
@@ -125,7 +125,7 @@ export function KanbanBoard({ cards, onCardStatusChange }: KanbanBoardProps) {
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex gap-4 overflow-x-auto pb-4 px-6 min-h-0 flex-1">
+      <div className="flex flex-col md:flex-row gap-4 overflow-y-auto md:overflow-x-auto pb-4 px-6 min-h-0 flex-1 md:justify-center">
         {KANBAN_COLUMNS.map((column) => (
           <KanbanColumn
             key={column.id}

--- a/src/renderer/components/KanbanColumn/KanbanColumn.tsx
+++ b/src/renderer/components/KanbanColumn/KanbanColumn.tsx
@@ -20,7 +20,7 @@ export function KanbanColumn({ id, label, color, bgColor, cards, isOver }: Kanba
   const cardIds = cards.map((card) => card.sessionUid);
 
   return (
-    <div className="flex flex-col w-72 min-w-72 h-full rounded-lg bg-gray-100/50">
+    <div className="flex flex-col w-full md:w-72 md:min-w-72 h-auto md:h-full rounded-lg bg-gray-100/50">
       {/* Column Header */}
       <div
         className="flex items-center gap-2 p-3 rounded-t-lg"


### PR DESCRIPTION
## Summary
- Center header and apply responsive max-width breakpoint (`md:`)
- Switch Kanban board from horizontal row to vertical column layout on mobile
- Make columns full-width on mobile, fixed 72 (18rem) width on desktop

## Test plan
- [ ] Verify layout on desktop (≥768px) displays horizontal columns
- [ ] Verify layout on mobile (<768px) displays stacked vertical columns
- [ ] Confirm header alignment matches board width on both breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)