### PR TITLE
Add create issue dialog with YAML template support

### DIFF
--- a/src/core/types/log.ts
+++ b/src/core/types/log.ts
@@ -49,7 +49,9 @@ export type UserActionType =
   | "project_clone"
   | "github_auth"
   | "open_terminal"
-  | "settings_save";
+  | "settings_save"
+  | "issue_created"
+  | "template_selected";
 
 // ============================================================================
 // Log Entry

--- a/src/renderer/components/CreateIssueDialog/CreateIssueDialog.tsx
+++ b/src/renderer/components/CreateIssueDialog/CreateIssueDialog.tsx
@@ -1,0 +1,339 @@
+/**
+ * CreateIssueDialog Component
+ * Modal for creating new GitHub issues with template support
+ */
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import { Label } from "../ui/label";
+import { MetadataSection } from "../DetailedCardView/MetadataSection";
+import { SidebarCard } from "../DetailedCardView/SidebarCard";
+import { useRepoMetadata } from "../DetailedCardView/hooks";
+import { useIssueTemplates } from "./hooks";
+import { createIssue, createMilestone, type IssueTemplate } from "@services/github";
+import { logUserAction, logDataSync, logPerformance } from "@services/logging";
+import type { CreateIssueDialogProps, CreateIssueState } from "./types";
+
+const INITIAL_STATE: CreateIssueState = {
+  title: "",
+  body: "",
+  labels: [],
+  assignees: [],
+  milestone: null,
+};
+
+export function CreateIssueDialog({
+  isOpen,
+  onClose,
+  onIssueCreated,
+  repo,
+}: CreateIssueDialogProps) {
+  const [formState, setFormState] = useState<CreateIssueState>(INITIAL_STATE);
+  const [selectedTemplate, setSelectedTemplate] = useState<IssueTemplate | null>(null);
+  const [additionalMilestones, setAdditionalMilestones] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Fetch templates and repo metadata
+  const { templates, isLoading: isLoadingTemplates } = useIssueTemplates(repo, isOpen);
+  const { metadata: fetchedMetadata, isLoading: isLoadingMetadata } = useRepoMetadata(repo, isOpen);
+
+  // Merge fetched metadata with locally created milestones
+  const repoMetadata = useMemo(
+    () => ({
+      labels: fetchedMetadata.labels,
+      collaborators: fetchedMetadata.collaborators,
+      milestones: [...fetchedMetadata.milestones, ...additionalMilestones],
+    }),
+    [fetchedMetadata, additionalMilestones]
+  );
+
+  // Reset form when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setFormState(INITIAL_STATE);
+      setSelectedTemplate(null);
+      setSubmitError(null);
+      setAdditionalMilestones([]);
+      logUserAction("modal_open", "CreateIssueDialog opened", { repo });
+    }
+  }, [isOpen, repo]);
+
+  // Handle Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Handle template selection
+  const handleTemplateSelect = useCallback(
+    (template: IssueTemplate | null) => {
+      setSelectedTemplate(template);
+      if (template) {
+        setFormState((prev) => ({
+          ...prev,
+          body: template.body,
+          labels: template.labels ?? prev.labels,
+        }));
+        logUserAction("template_selected", "Issue template selected", {
+          templateName: template.name,
+        });
+      } else {
+        // Reset to blank
+        setFormState((prev) => ({
+          ...prev,
+          body: "",
+        }));
+      }
+    },
+    []
+  );
+
+  const handleTitleChange = useCallback((title: string) => {
+    setFormState((prev) => ({ ...prev, title }));
+  }, []);
+
+  const handleBodyChange = useCallback((body: string) => {
+    setFormState((prev) => ({ ...prev, body }));
+  }, []);
+
+  const handleLabelsChange = useCallback((labels: string[]) => {
+    setFormState((prev) => ({ ...prev, labels }));
+  }, []);
+
+  const handleAssigneesChange = useCallback((assignees: string[]) => {
+    setFormState((prev) => ({ ...prev, assignees }));
+  }, []);
+
+  const handleMilestoneChange = useCallback((milestone: string | null) => {
+    setFormState((prev) => ({ ...prev, milestone }));
+  }, []);
+
+  const handleCreateMilestone = useCallback(
+    async (title: string): Promise<boolean> => {
+      const result = await createMilestone(repo, title);
+      if (result.ok) {
+        setAdditionalMilestones((prev) => [...prev, title]);
+        logDataSync("info", "Milestone created", { repo, title });
+        return true;
+      }
+      logDataSync("error", "Failed to create milestone", { title, error: result.error.message });
+      return false;
+    },
+    [repo]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!formState.title.trim()) {
+      setSubmitError("Title is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    const startTime = performance.now();
+
+    try {
+      const result = await createIssue(repo, {
+        title: formState.title.trim(),
+        body: formState.body.trim() || undefined,
+        labels: formState.labels.length > 0 ? formState.labels : undefined,
+        assignees: formState.assignees.length > 0 ? formState.assignees : undefined,
+        milestone: formState.milestone ?? undefined,
+      });
+
+      const elapsed = Math.round(performance.now() - startTime);
+
+      if (result.ok) {
+        logUserAction("issue_created", "New issue created", {
+          issueNumber: result.value.issueNumber,
+          repo,
+        });
+        logPerformance("Issue creation completed", elapsed, {
+          issueNumber: result.value.issueNumber,
+        });
+
+        if (result.value.issueNumber) {
+          onIssueCreated(result.value.issueNumber);
+        }
+        onClose();
+      } else {
+        logDataSync("error", "Failed to create issue", {
+          repo,
+          error: result.error.message,
+          elapsed,
+        });
+        setSubmitError(result.error.message);
+      }
+    } catch (error) {
+      const elapsed = Math.round(performance.now() - startTime);
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logDataSync("error", "Exception while creating issue", {
+        repo,
+        error: errorMessage,
+        elapsed,
+      });
+      setSubmitError(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [formState, repo, onIssueCreated, onClose]);
+
+  const handleCancel = useCallback(() => {
+    logUserAction("modal_close", "CreateIssueDialog cancelled", { repo });
+    onClose();
+  }, [onClose, repo]);
+
+  const isValid = formState.title.trim().length > 0;
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-2xl md:max-w-4xl bg-gray-50 rounded-xl shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">New Issue</h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Template Selector */}
+        {(templates.length > 0 || isLoadingTemplates) && (
+          <div className="px-6 py-3 border-b border-gray-200 bg-gray-100">
+            <div className="flex items-center gap-3">
+              <Label className="text-sm font-medium text-gray-700 whitespace-nowrap">
+                Template:
+              </Label>
+              {isLoadingTemplates ? (
+                <div className="h-9 w-48 bg-gray-200 rounded animate-pulse" />
+              ) : (
+                <select
+                  className="flex h-9 w-full max-w-xs rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  value={selectedTemplate?.name ?? ""}
+                  onChange={(e) => {
+                    const template = templates.find((t) => t.name === e.target.value) ?? null;
+                    handleTemplateSelect(template);
+                  }}
+                >
+                  <option value="">Blank Issue</option>
+                  {templates.map((template) => (
+                    <option key={template.name} value={template.name}>
+                      {template.name}
+                      {template.about ? ` - ${template.about}` : ""}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="px-6 py-5 max-h-[60vh] overflow-y-auto">
+          <div className="flex flex-col md:grid md:grid-cols-[1fr_280px] md:gap-6 md:items-stretch">
+            {/* Left column: Issue details */}
+            <div className="flex flex-col">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="issue-title"
+                  className="text-sm font-semibold text-gray-500 uppercase tracking-wide"
+                >
+                  Title <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="issue-title"
+                  value={formState.title}
+                  onChange={(e) => handleTitleChange(e.target.value)}
+                  className="w-full"
+                  placeholder="Issue title"
+                  autoFocus
+                />
+              </div>
+              <div className="flex flex-col flex-grow mt-4">
+                <Label
+                  htmlFor="issue-body"
+                  className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2"
+                >
+                  Description
+                </Label>
+                <Textarea
+                  id="issue-body"
+                  value={formState.body}
+                  onChange={(e) => handleBodyChange(e.target.value)}
+                  className="w-full flex-grow min-h-[180px] resize-none"
+                  placeholder="Issue description (supports markdown)"
+                />
+              </div>
+            </div>
+
+            {/* Right column: Metadata */}
+            <div className="space-y-6 mt-6 md:mt-0">
+              <SidebarCard title="Metadata">
+                <MetadataSection
+                  labels={formState.labels}
+                  assignees={formState.assignees}
+                  milestone={formState.milestone}
+                  availableLabels={repoMetadata.labels}
+                  availableCollaborators={repoMetadata.collaborators}
+                  availableMilestones={repoMetadata.milestones}
+                  onLabelsChange={handleLabelsChange}
+                  onAssigneesChange={handleAssigneesChange}
+                  onMilestoneChange={handleMilestoneChange}
+                  onCreateMilestone={handleCreateMilestone}
+                  isLoadingMetadata={isLoadingMetadata}
+                />
+              </SidebarCard>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-xl">
+          <div>
+            {submitError && (
+              <span className="text-sm text-red-600">{submitError}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={handleCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={!isValid || isSubmitting}>
+              {isSubmitting ? "Creating..." : "Create Issue"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/CreateIssueDialog/hooks.ts
+++ b/src/renderer/components/CreateIssueDialog/hooks.ts
@@ -1,0 +1,65 @@
+/**
+ * CreateIssueDialog Hooks
+ * Custom hooks for the create issue dialog component
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { fetchIssueTemplates, type IssueTemplate } from "@services/github";
+import { logDataSync } from "@services/logging";
+import type { UseIssueTemplatesResult } from "./types";
+
+/**
+ * Hook to fetch issue templates for a repository
+ * Caches results to avoid repeated API calls
+ */
+export function useIssueTemplates(
+  repo: string | null,
+  isOpen: boolean
+): UseIssueTemplatesResult {
+  const [templates, setTemplates] = useState<IssueTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cacheRef = useRef<Map<string, IssueTemplate[]>>(new Map());
+
+  useEffect(() => {
+    if (!repo || !isOpen) {
+      return;
+    }
+
+    // Check cache first
+    const cached = cacheRef.current.get(repo);
+    if (cached) {
+      setTemplates(cached);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    logDataSync("debug", "Fetching issue templates", { repo });
+
+    fetchIssueTemplates(repo)
+      .then((result) => {
+        if (result.ok) {
+          setTemplates(result.value);
+          cacheRef.current.set(repo, result.value);
+          logDataSync("info", "Issue templates fetched", {
+            repo,
+            count: result.value.length,
+          });
+        } else {
+          // Log error but don't show to user - templates are optional
+          logDataSync("warn", "Failed to fetch issue templates", {
+            repo,
+            error: result.error.message,
+          });
+          setTemplates([]);
+        }
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [repo, isOpen]);
+
+  return { templates, isLoading, error };
+}

--- a/src/renderer/components/CreateIssueDialog/index.ts
+++ b/src/renderer/components/CreateIssueDialog/index.ts
@@ -1,0 +1,7 @@
+/**
+ * CreateIssueDialog Component
+ * Modal for creating new GitHub issues with template support
+ */
+
+export { CreateIssueDialog } from "./CreateIssueDialog";
+export type { CreateIssueDialogProps, CreateIssueState } from "./types";

--- a/src/renderer/components/CreateIssueDialog/types.ts
+++ b/src/renderer/components/CreateIssueDialog/types.ts
@@ -1,0 +1,34 @@
+/**
+ * CreateIssueDialog Types
+ * Type definitions for the create issue dialog and its sub-components
+ */
+
+import type { IssueTemplate } from "@services/github";
+
+export interface CreateIssueDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onIssueCreated: (issueNumber: number) => void;
+  repo: string;
+}
+
+export interface CreateIssueState {
+  title: string;
+  body: string;
+  labels: string[];
+  assignees: string[];
+  milestone: string | null;
+}
+
+export interface UseIssueTemplatesResult {
+  templates: IssueTemplate[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface TemplateSelectorProps {
+  templates: IssueTemplate[];
+  selectedTemplate: IssueTemplate | null;
+  onSelectTemplate: (template: IssueTemplate | null) => void;
+  isLoading: boolean;
+}

--- a/src/renderer/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/renderer/components/KanbanBoard/KanbanBoard.tsx
@@ -22,9 +22,10 @@ interface KanbanBoardProps {
   cards: Card[];
   onCardStatusChange: (cardId: string, newStatus: CardStatus) => void;
   onCardClick?: (card: Card) => void;
+  onCreateIssue?: () => void;
 }
 
-export function KanbanBoard({ cards, onCardStatusChange, onCardClick }: KanbanBoardProps) {
+export function KanbanBoard({ cards, onCardStatusChange, onCardClick, onCreateIssue }: KanbanBoardProps) {
   const [activeCard, setActiveCard] = useState<Card | null>(null);
   const [activeColumnId, setActiveColumnId] = useState<string | null>(null);
 
@@ -137,6 +138,7 @@ export function KanbanBoard({ cards, onCardStatusChange, onCardClick }: KanbanBo
             cards={cardsByStatus[column.id]}
             isOver={activeColumnId === column.id}
             onCardClick={onCardClick}
+            onCreateIssue={column.id === 'idle' ? onCreateIssue : undefined}
           />
         ))}
       </div>

--- a/src/renderer/components/KanbanColumn/KanbanColumn.tsx
+++ b/src/renderer/components/KanbanColumn/KanbanColumn.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { Card } from '@core/types/card';
@@ -12,6 +12,7 @@ interface KanbanColumnProps {
   cards: Card[];
   isOver: boolean;
   onCardClick?: (card: Card) => void;
+  onCreateIssue?: () => void;
 }
 
 export const KanbanColumn = memo(function KanbanColumn({
@@ -22,6 +23,7 @@ export const KanbanColumn = memo(function KanbanColumn({
   cards,
   isOver,
   onCardClick,
+  onCreateIssue,
 }: KanbanColumnProps) {
   const { setNodeRef } = useDroppable({
     id,
@@ -29,6 +31,14 @@ export const KanbanColumn = memo(function KanbanColumn({
 
   // Memoize card IDs to prevent unnecessary re-renders of SortableContext
   const cardIds = useMemo(() => cards.map((card) => card.sessionUid), [cards]);
+
+  const handleCreateClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onCreateIssue?.();
+    },
+    [onCreateIssue]
+  );
 
   return (
     <div className="flex flex-col w-full md:w-72 md:min-w-72 h-auto md:h-full rounded-lg bg-gray-100/50">
@@ -42,12 +52,32 @@ export const KanbanColumn = memo(function KanbanColumn({
           style={{ backgroundColor: color }}
         />
         <span className="font-medium text-gray-700">{label}</span>
-        <span
-          className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full"
-          style={{ backgroundColor: color, color: 'white' }}
-        >
-          {cards.length}
-        </span>
+        <div className="ml-auto flex items-center gap-1.5">
+          <span
+            className="text-xs font-medium px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: color, color: 'white' }}
+          >
+            {cards.length}
+          </span>
+          {onCreateIssue && (
+            <button
+              onClick={handleCreateClick}
+              className="p-1 rounded-md text-gray-500 hover:text-gray-700 hover:bg-white/50 transition-colors"
+              aria-label="Create new issue"
+              title="Create new issue"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Card List */}
@@ -62,10 +92,29 @@ export const KanbanColumn = memo(function KanbanColumn({
             <SortableCard key={card.sessionUid} card={card} onClick={onCardClick} />
           ))}
         </SortableContext>
-        {cards.length === 0 && (
+        {cards.length === 0 && !onCreateIssue && (
           <div className="h-full flex items-center justify-center text-gray-400 text-sm">
             Drop cards here
           </div>
+        )}
+        {/* Bottom + button for creating new issues */}
+        {onCreateIssue && (
+          <button
+            onClick={handleCreateClick}
+            className="w-full py-3 px-4 border-2 border-dashed border-gray-300 rounded-lg text-gray-500 hover:border-gray-400 hover:text-gray-600 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+            aria-label="Create new issue"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            <span className="text-sm font-medium">New Issue</span>
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add "+" buttons to Idle column (header and bottom) for creating new issues
- Create `CreateIssueDialog` component with full metadata support (title, body, labels, assignees, milestone)
- Add `createIssue()` and `fetchIssueTemplates()` functions to github service
- Support both markdown (`.md`) and YAML form templates (`.yml`/`.yaml`)
- Convert YAML form elements (markdown, input, textarea, dropdown, checkboxes) to readable markdown for display

## Changes
| File | Description |
|------|-------------|
| `src/services/github.ts` | Add `createIssue()`, `fetchIssueTemplates()`, and YAML template parsing |
| `src/renderer/components/CreateIssueDialog/` | New dialog component with template selector |
| `src/renderer/components/KanbanColumn/` | Add + buttons (Idle column only) |
| `src/renderer/components/KanbanBoard/` | Pass through `onCreateIssue` handler |
| `src/renderer/App.tsx` | Integrate dialog state and handlers |

## Test plan
- [x] Click + button in Idle column header → dialog opens
- [x] Click + button at bottom of Idle column → dialog opens
- [x] Template dropdown shows "Blank Issue" plus available templates
- [x] Selecting a YAML template shows converted markdown body
- [x] Selecting a markdown template shows template body correctly
- [x] Fill in title and submit → issue created on GitHub
- [x] New card appears in Idle column after creation
- [x] Cancel closes dialog without creating issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)