### PR TITLE
Strip markdown headings from card descriptions

### DIFF
--- a/src/renderer/components/KanbanColumn/SortableCard.tsx
+++ b/src/renderer/components/KanbanColumn/SortableCard.tsx
@@ -3,6 +3,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Card } from '@core/types/card';
 import { KanbanCard } from '../KanbanCard';
+import { stripMarkdownHeadings } from '../../utils/text';
 
 interface SortableCardProps {
   card: Card;
@@ -65,7 +66,7 @@ export const SortableCard = memo(function SortableCard({ card, onClick }: Sortab
     >
       <KanbanCard
         title={card.github.title}
-        description={card.github.body}
+        description={stripMarkdownHeadings(card.github.body)}
         labels={card.github.labels}
         hasError={card.hasError}
         isDragging={isDragging}

--- a/src/renderer/utils/text.ts
+++ b/src/renderer/utils/text.ts
@@ -1,0 +1,37 @@
+/**
+ * Strips leading markdown headings from text.
+ *
+ * Removes consecutive markdown headings (lines starting with #) and empty lines
+ * from the beginning of text, returning the first line of actual content.
+ * Falls back to the first heading text (without # symbols) if no content remains.
+ */
+export function stripMarkdownHeadings(text: string): string {
+  if (!text) return '';
+
+  const lines = text.split('\n');
+  let startIndex = 0;
+  let firstHeadingText: string | null = null;
+
+  // Skip leading headings and empty lines
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#')) {
+      // Extract heading text (remove # symbols and leading space)
+      if (firstHeadingText === null) {
+        firstHeadingText = trimmed.replace(/^#+\s*/, '');
+      }
+      startIndex = i + 1;
+    } else if (trimmed === '') {
+      startIndex = i + 1;
+    } else {
+      break;
+    }
+  }
+
+  const content = lines.slice(startIndex).join('\n').trim();
+
+  // Fallback to first heading text if no content remains
+  return content || firstHeadingText || '';
+}


### PR DESCRIPTION
## Summary
- Add `stripMarkdownHeadings()` utility function to remove leading markdown headings from text
- Apply the utility when displaying card descriptions in the Kanban view
- Falls back to showing the heading text (without `#` symbols) if no other content exists

## Problem
Card descriptions on the Kanban board displayed raw markdown heading syntax (e.g., `### Problem Statement`), creating visual clutter.

## Solution
Strip markdown headings from the beginning of card descriptions so only the first line of actual content is shown.

**Example:**
```
### Problem Statement
Users cannot reset their password via email
```
Now displays as: `Users cannot reset their password via email`

## Test plan
- [x] Run `bun run dev` and verify cards with markdown headings show content without `#` symbols
- [x] Verify cards without headings display normally
- [x] Verify cards with only headings (no content) show the heading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)