### PR TITLE
feat: Fixed terminal size for Agent view with configurable dimensions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "tailwindcss-animate": "^1.0.7",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0",
+        "xterm-addon-unicode11": "^0.6.0",
         "xterm-addon-web-links": "^0.9.0",
       },
       "devDependencies": {
@@ -755,6 +756,8 @@
     "xterm": ["xterm@5.3.0", "", {}, "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg=="],
 
     "xterm-addon-fit": ["xterm-addon-fit@0.8.0", "", { "peerDependencies": { "xterm": "^5.0.0" } }, "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw=="],
+
+    "xterm-addon-unicode11": ["xterm-addon-unicode11@0.6.0", "", { "peerDependencies": { "xterm": "^5.0.0" } }, "sha512-5pkb8YoS/deRtNqQRw8t640mu+Ga8B2MG3RXGQu0bwgcfr8XiXIRI880TWM49ICAHhTmnOLPzIIBIjEnCq7k2A=="],
 
     "xterm-addon-web-links": ["xterm-addon-web-links@0.9.0", "", { "peerDependencies": { "xterm": "^5.0.0" } }, "sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tailwindcss-animate": "^1.0.7",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-unicode11": "^0.6.0",
     "xterm-addon-web-links": "^0.9.0"
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -19,7 +19,7 @@ import { NotificationProvider } from './context/NotificationContext';
 import { NotificationContainer } from './components/ui/NotificationContainer';
 import { NotificationPopover } from './components/ui/NotificationPopover';
 import { ErrorBoundary, CompactFallback } from './components/ErrorBoundary';
-import { getCachedConfig, clearConfigCache, loadConfig } from '@services/config';
+import { getCachedConfig, clearConfigCache, loadConfig, getTerminalCols, getTerminalRows, DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from '@services/config';
 import { initLogger, shutdownLogger, logSystem, logUserAction } from '@services/logging';
 
 function ActionButton({
@@ -176,6 +176,7 @@ export default function App() {
   const [selectedAgentCardId, setSelectedAgentCardId] = useState<string | null>(null);
   const [showProjectSelector, setShowProjectSelector] = useState(false);
   const [isCreateIssueOpen, setIsCreateIssueOpen] = useState(false);
+  const [terminalDimensions, setTerminalDimensions] = useState({ cols: DEFAULT_TERMINAL_COLS, rows: DEFAULT_TERMINAL_ROWS });
   const hasInitialized = useRef(false);
 
   const handleCardClick = useCallback((card: Card) => {
@@ -252,6 +253,13 @@ export default function App() {
     };
   }, []);
 
+  // Load terminal dimensions from config
+  useEffect(() => {
+    Promise.all([getTerminalCols(), getTerminalRows()]).then(([cols, rows]) => {
+      setTerminalDimensions({ cols, rows });
+    });
+  }, []);
+
   const renderContent = () => {
     // Show loading while project selector is initializing
     if (projectSelector.isLoading || !hasInitialized.current) {
@@ -313,6 +321,8 @@ export default function App() {
               cards={cards}
               selectedCardId={selectedAgentCardId}
               onCardSelect={setSelectedAgentCardId}
+              terminalCols={terminalDimensions.cols}
+              terminalRows={terminalDimensions.rows}
             />
           </div>
         )}
@@ -322,6 +332,11 @@ export default function App() {
 
   const handleConfigChange = async () => {
     clearConfigCache();
+
+    // Reload terminal dimensions (applies even in mock mode)
+    const [cols, rows] = await Promise.all([getTerminalCols(), getTerminalRows()]);
+    setTerminalDimensions({ cols, rows });
+
     if (!isMock) {
       setCards([]);  // Clear old cards before loading new project
       // Reload from global config (project service auto-saves on project switch)

--- a/src/renderer/components/AgentView/AgentView.tsx
+++ b/src/renderer/components/AgentView/AgentView.tsx
@@ -8,12 +8,16 @@ interface AgentViewProps {
   cards: readonly Card[];
   selectedCardId: string | null;
   onCardSelect: (cardId: string) => void;
+  terminalCols: number;
+  terminalRows: number;
 }
 
 export const AgentView = memo(function AgentView({
   cards,
   selectedCardId,
   onCardSelect,
+  terminalCols,
+  terminalRows,
 }: AgentViewProps) {
   const selectedCard = selectedCardId
     ? cards.find((c) => c.sessionUid === selectedCardId) ?? null
@@ -33,7 +37,11 @@ export const AgentView = memo(function AgentView({
 
         {/* Terminal panel - 70% */}
         <div className="flex-1 min-w-0">
-          <TerminalPanel selectedCard={selectedCard} />
+          <TerminalPanel
+            selectedCard={selectedCard}
+            terminalCols={terminalCols}
+            terminalRows={terminalRows}
+          />
         </div>
       </div>
     </AgentSessionProvider>

--- a/src/renderer/components/AgentView/TerminalContainer.tsx
+++ b/src/renderer/components/AgentView/TerminalContainer.tsx
@@ -6,6 +6,8 @@ import { Badge } from "../ui/badge";
 interface TerminalContainerProps {
   card: Card;
   isVisible: boolean;
+  terminalCols?: number;
+  terminalRows?: number;
 }
 
 const STATUS_COLORS = {
@@ -18,11 +20,15 @@ const STATUS_COLORS = {
 export const TerminalContainer = memo(function TerminalContainer({
   card,
   isVisible,
+  terminalCols,
+  terminalRows,
 }: TerminalContainerProps) {
-  const { containerRef, status, error } = useTerminal({
+  const { containerRef, terminalMountRef, status, error, scale } = useTerminal({
     worktreePath: card.worktreePath ?? "",
     port: card.port,
     autoStart: true,
+    cols: terminalCols,
+    rows: terminalRows,
   });
 
   const issueNumber = card.github.issueNumber;
@@ -61,12 +67,21 @@ export const TerminalContainer = memo(function TerminalContainer({
         </div>
       </div>
 
-      {/* Terminal content */}
+      {/* Terminal content - outer container for measuring available space */}
       <div
         ref={containerRef}
-        className="flex-1 min-h-0"
-        style={{ padding: "4px" }}
-      />
+        className="flex-1 min-h-0 overflow-hidden"
+      >
+        {/* Inner container where xterm mounts - gets scaled */}
+        <div
+          ref={terminalMountRef}
+          style={{
+            transformOrigin: 'top left',
+            transform: `scale(${scale})`,
+            padding: '4px',
+          }}
+        />
+      </div>
 
       {/* Error display */}
       {error && status === "error" && (

--- a/src/renderer/components/AgentView/TerminalPanel.tsx
+++ b/src/renderer/components/AgentView/TerminalPanel.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useEffect } from "react";
 import type { Card } from "@core/types";
 import { TerminalContainer } from "./TerminalContainer";
+import { getTerminalCols, getTerminalRows, DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from "@services/config";
 
 interface TerminalPanelProps {
   selectedCard: Card | null;
@@ -11,6 +12,18 @@ export const TerminalPanel = memo(function TerminalPanel({
 }: TerminalPanelProps) {
   // Track cards that have been viewed (to keep their terminals alive)
   const [viewedCards, setViewedCards] = useState<Map<string, Card>>(new Map());
+
+  // Terminal dimension settings
+  const [terminalCols, setTerminalCols] = useState<number>(DEFAULT_TERMINAL_COLS);
+  const [terminalRows, setTerminalRows] = useState<number>(DEFAULT_TERMINAL_ROWS);
+
+  // Load terminal dimensions from config on mount
+  useEffect(() => {
+    Promise.all([getTerminalCols(), getTerminalRows()]).then(([cols, rows]) => {
+      setTerminalCols(cols);
+      setTerminalRows(rows);
+    });
+  }, []);
 
   // Add selected card to viewed cards when it changes
   useEffect(() => {
@@ -68,6 +81,8 @@ export const TerminalPanel = memo(function TerminalPanel({
           <TerminalContainer
             card={card}
             isVisible={card.sessionUid === selectedCard.sessionUid}
+            terminalCols={terminalCols}
+            terminalRows={terminalRows}
           />
         </div>
       ))}

--- a/src/renderer/components/AgentView/TerminalPanel.tsx
+++ b/src/renderer/components/AgentView/TerminalPanel.tsx
@@ -1,29 +1,20 @@
 import { memo, useState, useEffect } from "react";
 import type { Card } from "@core/types";
 import { TerminalContainer } from "./TerminalContainer";
-import { getTerminalCols, getTerminalRows, DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from "@services/config";
 
 interface TerminalPanelProps {
   selectedCard: Card | null;
+  terminalCols: number;
+  terminalRows: number;
 }
 
 export const TerminalPanel = memo(function TerminalPanel({
   selectedCard,
+  terminalCols,
+  terminalRows,
 }: TerminalPanelProps) {
   // Track cards that have been viewed (to keep their terminals alive)
   const [viewedCards, setViewedCards] = useState<Map<string, Card>>(new Map());
-
-  // Terminal dimension settings
-  const [terminalCols, setTerminalCols] = useState<number>(DEFAULT_TERMINAL_COLS);
-  const [terminalRows, setTerminalRows] = useState<number>(DEFAULT_TERMINAL_ROWS);
-
-  // Load terminal dimensions from config on mount
-  useEffect(() => {
-    Promise.all([getTerminalCols(), getTerminalRows()]).then(([cols, rows]) => {
-      setTerminalCols(cols);
-      setTerminalRows(rows);
-    });
-  }, []);
 
   // Add selected card to viewed cards when it changes
   useEffect(() => {

--- a/src/renderer/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel/SettingsPanel.tsx
@@ -131,6 +131,8 @@ export function SettingsPanel({ isOpen, onClose, onConfigChange }: SettingsPanel
               postOpenCommand={settings.postOpenCommand}
               autoPromptClaude={settings.autoPromptClaude}
               claudeStartupDelay={settings.claudeStartupDelay}
+              terminalCols={settings.terminalCols}
+              terminalRows={settings.terminalRows}
               onSave={settings.saveTerminalSettings}
             />
           </SettingsGroup>

--- a/src/renderer/components/SettingsPanel/TerminalSettingsSection.tsx
+++ b/src/renderer/components/SettingsPanel/TerminalSettingsSection.tsx
@@ -6,14 +6,16 @@
 import { useState, useEffect } from "react";
 import { Button } from "../ui/button";
 import { logConfig, logUserAction } from "@services/logging";
-import { DEFAULT_CLAUDE_STARTUP_DELAY } from "@services/config";
+import { DEFAULT_CLAUDE_STARTUP_DELAY, DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from "@services/config";
 
 interface TerminalSettingsSectionProps {
   terminalApp: string | null;
   postOpenCommand: string | null;
   autoPromptClaude: boolean | null;
   claudeStartupDelay: number | null;
-  onSave: (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number) => Promise<void>;
+  terminalCols: number | null;
+  terminalRows: number | null;
+  onSave: (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number, cols: number, rows: number) => Promise<void>;
 }
 
 export function TerminalSettingsSection({
@@ -21,12 +23,16 @@ export function TerminalSettingsSection({
   postOpenCommand,
   autoPromptClaude: autoPromptClaudeProp,
   claudeStartupDelay: claudeStartupDelayProp,
+  terminalCols: terminalColsProp,
+  terminalRows: terminalRowsProp,
   onSave,
 }: TerminalSettingsSectionProps) {
   const [app, setApp] = useState("");
   const [command, setCommand] = useState("");
   const [autoPromptClaude, setAutoPromptClaude] = useState(false);
   const [claudeStartupDelay, setClaudeStartupDelay] = useState(DEFAULT_CLAUDE_STARTUP_DELAY);
+  const [cols, setCols] = useState(DEFAULT_TERMINAL_COLS);
+  const [rows, setRows] = useState(DEFAULT_TERMINAL_ROWS);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
@@ -36,13 +42,17 @@ export function TerminalSettingsSection({
     setCommand(postOpenCommand ?? "");
     setAutoPromptClaude(autoPromptClaudeProp ?? false);
     setClaudeStartupDelay(claudeStartupDelayProp ?? DEFAULT_CLAUDE_STARTUP_DELAY);
-  }, [terminalApp, postOpenCommand, autoPromptClaudeProp, claudeStartupDelayProp]);
+    setCols(terminalColsProp ?? DEFAULT_TERMINAL_COLS);
+    setRows(terminalRowsProp ?? DEFAULT_TERMINAL_ROWS);
+  }, [terminalApp, postOpenCommand, autoPromptClaudeProp, claudeStartupDelayProp, terminalColsProp, terminalRowsProp]);
 
   const hasChanges =
     app !== (terminalApp ?? "") ||
     command !== (postOpenCommand ?? "") ||
     autoPromptClaude !== (autoPromptClaudeProp ?? false) ||
-    claudeStartupDelay !== (claudeStartupDelayProp ?? DEFAULT_CLAUDE_STARTUP_DELAY);
+    claudeStartupDelay !== (claudeStartupDelayProp ?? DEFAULT_CLAUDE_STARTUP_DELAY) ||
+    cols !== (terminalColsProp ?? DEFAULT_TERMINAL_COLS) ||
+    rows !== (terminalRowsProp ?? DEFAULT_TERMINAL_ROWS);
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -53,16 +63,20 @@ export function TerminalSettingsSection({
       hasCommand: Boolean(command),
       autoPromptClaude,
       claudeStartupDelay,
+      cols,
+      rows,
     });
 
     try {
-      await onSave(app, command, autoPromptClaude, claudeStartupDelay);
+      await onSave(app, command, autoPromptClaude, claudeStartupDelay, cols, rows);
       setSaveSuccess(true);
       logUserAction("settings_save", "Terminal settings saved successfully", {
         app: app || "(default)",
         hasCommand: Boolean(command),
         autoPromptClaude,
         claudeStartupDelay,
+        cols,
+        rows,
       });
       setTimeout(() => setSaveSuccess(false), 2000);
     } catch (e) {
@@ -188,6 +202,52 @@ export function TerminalSettingsSection({
           </p>
         </div>
       )}
+
+      {/* Terminal Dimensions */}
+      <div className="space-y-1.5">
+        <label className="block text-sm font-medium text-gray-700">
+          Agent Terminal Dimensions
+        </label>
+        <div className="flex items-center gap-3">
+          <input
+            id="terminal-cols"
+            type="number"
+            value={cols}
+            onChange={(e) => {
+              const value = parseInt(e.target.value, 10);
+              if (!isNaN(value)) {
+                const clamped = Math.min(200, Math.max(40, value));
+                setCols(clamped);
+                setSaveSuccess(false);
+              }
+            }}
+            min={40}
+            max={200}
+            className="w-20 px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-gray-50"
+          />
+          <span className="text-gray-500">×</span>
+          <input
+            id="terminal-rows"
+            type="number"
+            value={rows}
+            onChange={(e) => {
+              const value = parseInt(e.target.value, 10);
+              if (!isNaN(value)) {
+                const clamped = Math.min(100, Math.max(10, value));
+                setRows(clamped);
+                setSaveSuccess(false);
+              }
+            }}
+            min={10}
+            max={100}
+            className="w-20 px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-gray-50"
+          />
+          <span className="text-xs text-gray-500">columns × rows</span>
+        </div>
+        <p className="text-xs text-gray-500">
+          Fixed terminal size for the Agent view (default: 80×24). Scales to fit when window is smaller.
+        </p>
+      </div>
 
       {/* Save Button */}
       <div className="flex justify-end">

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -17,7 +17,11 @@ import {
   getPostOpenCommand,
   getAutoPromptClaude,
   getClaudeStartupDelay,
+  getTerminalCols,
+  getTerminalRows,
   DEFAULT_CLAUDE_STARTUP_DELAY,
+  DEFAULT_TERMINAL_COLS,
+  DEFAULT_TERMINAL_ROWS,
 } from "@services/config";
 import { checkGitHubAuth } from "@services/github";
 import { logConfig, logDataSync } from "@services/logging";
@@ -42,6 +46,8 @@ interface SettingsState {
   postOpenCommand: string | null;
   autoPromptClaude: boolean | null;
   claudeStartupDelay: number | null;
+  terminalCols: number | null;
+  terminalRows: number | null;
 }
 
 export function useSettings() {
@@ -60,6 +66,8 @@ export function useSettings() {
     postOpenCommand: null,
     autoPromptClaude: null,
     claudeStartupDelay: null,
+    terminalCols: null,
+    terminalRows: null,
   });
 
   const checkConfig = useCallback(async () => {
@@ -147,11 +155,13 @@ export function useSettings() {
 
   const loadTerminalSettings = useCallback(async () => {
     logConfig("debug", "Loading terminal settings");
-    const [app, command, autoPrompt, startupDelay] = await Promise.all([
+    const [app, command, autoPrompt, startupDelay, cols, rows] = await Promise.all([
       getTerminalApp(),
       getPostOpenCommand(),
       getAutoPromptClaude(),
       getClaudeStartupDelay(),
+      getTerminalCols(),
+      getTerminalRows(),
     ]);
     setState((prev) => ({
       ...prev,
@@ -159,23 +169,26 @@ export function useSettings() {
       postOpenCommand: command,
       autoPromptClaude: autoPrompt,
       claudeStartupDelay: startupDelay,
+      terminalCols: cols,
+      terminalRows: rows,
     }));
-    logConfig("debug", "Terminal settings loaded", { app, command, autoPromptClaude: autoPrompt, claudeStartupDelay: startupDelay });
+    logConfig("debug", "Terminal settings loaded", { app, command, autoPromptClaude: autoPrompt, claudeStartupDelay: startupDelay, cols, rows });
   }, []);
 
-  const saveTerminalSettings = useCallback(async (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number): Promise<void> => {
-    logConfig("info", "Saving terminal settings", { app, command, autoPromptClaude, claudeStartupDelay });
+  const saveTerminalSettings = useCallback(async (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number, cols: number, rows: number): Promise<void> => {
+    logConfig("info", "Saving terminal settings", { app, command, autoPromptClaude, claudeStartupDelay, cols, rows });
 
     // Load current config content and update it
     const contentResult = await getConfigContent();
     if (!contentResult.ok) {
       // Create new config with terminal settings
       logConfig("debug", "Config file does not exist, creating new config");
-      const hasTerminalSettings = app || command || autoPromptClaude;
+      const hasNonDefaultDimensions = cols !== DEFAULT_TERMINAL_COLS || rows !== DEFAULT_TERMINAL_ROWS;
+      const hasTerminalSettings = app || command || autoPromptClaude || hasNonDefaultDimensions;
       const newContent = `github:
   repository: ""
 ${hasTerminalSettings ? `terminal:
-${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n` : ""}${autoPromptClaude ? `  autoPromptClaude: true\n` : ""}${autoPromptClaude && claudeStartupDelay !== DEFAULT_CLAUDE_STARTUP_DELAY ? `  claudeStartupDelay: ${claudeStartupDelay}\n` : ""}` : ""}`;
+${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n` : ""}${autoPromptClaude ? `  autoPromptClaude: true\n` : ""}${autoPromptClaude && claudeStartupDelay !== DEFAULT_CLAUDE_STARTUP_DELAY ? `  claudeStartupDelay: ${claudeStartupDelay}\n` : ""}${cols !== DEFAULT_TERMINAL_COLS ? `  terminalCols: ${cols}\n` : ""}${rows !== DEFAULT_TERMINAL_ROWS ? `  terminalRows: ${rows}\n` : ""}` : ""}`;
       await saveConfigContent(newContent);
     } else {
       // Parse and update existing config
@@ -185,7 +198,8 @@ ${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n`
         const parsed = load(contentResult.value) as Record<string, unknown>;
 
         // Update terminal section
-        const hasTerminalSettings = app || command || autoPromptClaude;
+        const hasNonDefaultDimensions = cols !== DEFAULT_TERMINAL_COLS || rows !== DEFAULT_TERMINAL_ROWS;
+        const hasTerminalSettings = app || command || autoPromptClaude || hasNonDefaultDimensions;
         if (hasTerminalSettings) {
           parsed.terminal = {
             ...(app && { app }),
@@ -193,6 +207,9 @@ ${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n`
             ...(autoPromptClaude && { autoPromptClaude }),
             // Only save delay if auto-prompt is enabled and it's not the default
             ...(autoPromptClaude && claudeStartupDelay !== DEFAULT_CLAUDE_STARTUP_DELAY && { claudeStartupDelay }),
+            // Only save dimensions if they differ from defaults
+            ...(cols !== DEFAULT_TERMINAL_COLS && { terminalCols: cols }),
+            ...(rows !== DEFAULT_TERMINAL_ROWS && { terminalRows: rows }),
           };
         } else {
           delete parsed.terminal;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { Terminal } from "xterm";
 import { WebLinksAddon } from "xterm-addon-web-links";
+import { Unicode11Addon } from "xterm-addon-unicode11";
 import type { PtyHandle, AgentStatus } from "@core/types";
 import { spawnPty } from "@services/pty";
 import { logWorktree } from "@services/logging";
@@ -94,8 +95,16 @@ export function useTerminal({
       },
     });
 
+    // Load web links addon for clickable URLs
     const webLinksAddon = new WebLinksAddon();
     terminal.loadAddon(webLinksAddon);
+
+    // Load unicode11 addon for proper character width calculation
+    // This fixes rendering issues with modern Unicode symbols (spinners, box-drawing, etc.)
+    const unicode11Addon = new Unicode11Addon();
+    terminal.loadAddon(unicode11Addon);
+    terminal.unicode.activeVersion = "11";
+
     terminal.open(terminalMountRef.current);
 
     terminalRef.current = terminal;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { Terminal } from "xterm";
-import { FitAddon } from "xterm-addon-fit";
 import { WebLinksAddon } from "xterm-addon-web-links";
 import type { PtyHandle, AgentStatus } from "@core/types";
 import { spawnPty } from "@services/pty";
 import { logWorktree } from "@services/logging";
+import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from "@services/config";
 
 // Import xterm CSS
 import "xterm/css/xterm.css";
@@ -13,33 +13,59 @@ interface UseTerminalOptions {
   worktreePath: string;
   port: number | null;
   autoStart?: boolean;
+  cols?: number;
+  rows?: number;
 }
 
 interface UseTerminalReturn {
-  containerRef: React.RefObject<HTMLDivElement | null>;
+  containerRef: React.RefObject<HTMLDivElement>;
+  terminalMountRef: React.RefObject<HTMLDivElement>;
   status: AgentStatus;
   error: string | null;
   startAgent: () => Promise<void>;
   stopAgent: () => Promise<void>;
+  scale: number;
 }
 
 export function useTerminal({
   worktreePath,
   port,
   autoStart = true,
+  cols = DEFAULT_TERMINAL_COLS,
+  rows = DEFAULT_TERMINAL_ROWS,
 }: UseTerminalOptions): UseTerminalReturn {
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalMountRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
   const ptyRef = useRef<PtyHandle | null>(null);
+  const terminalSizeRef = useRef<{ width: number; height: number } | null>(null);
   const [status, setStatus] = useState<AgentStatus>("stopped");
   const [error, setError] = useState<string | null>(null);
+  const [scale, setScale] = useState<number>(1);
+
+  // Calculate scale to fit terminal within container
+  const calculateScale = useCallback(() => {
+    if (!containerRef.current || !terminalSizeRef.current) return;
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const termSize = terminalSizeRef.current;
+
+    // Calculate scale factors for both dimensions
+    const scaleX = containerRect.width / termSize.width;
+    const scaleY = containerRect.height / termSize.height;
+
+    // Use the smaller scale to fit within container, but never scale up
+    const newScale = Math.min(scaleX, scaleY, 1.0);
+    setScale(newScale);
+  }, []);
 
   // Initialize xterm.js terminal
   useEffect(() => {
-    if (!containerRef.current || terminalRef.current) return;
+    if (!terminalMountRef.current || terminalRef.current) return;
 
     const terminal = new Terminal({
+      cols,
+      rows,
       cursorBlink: true,
       fontSize: 14,
       fontFamily: '"MesloLGS NF", "JetBrainsMono Nerd Font", "FiraCode Nerd Font", "Hack Nerd Font", Menlo, Monaco, "Courier New", monospace',
@@ -68,43 +94,37 @@ export function useTerminal({
       },
     });
 
-    const fitAddon = new FitAddon();
     const webLinksAddon = new WebLinksAddon();
-
-    terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);
-    terminal.open(containerRef.current);
-
-    // Initial fit
-    fitAddon.fit();
+    terminal.open(terminalMountRef.current);
 
     terminalRef.current = terminal;
-    fitAddonRef.current = fitAddon;
 
-    // Handle window resize
-    const handleResize = () => {
-      if (fitAddonRef.current && terminalRef.current) {
-        fitAddonRef.current.fit();
-        // Notify PTY of resize
-        if (ptyRef.current) {
-          const { cols, rows } = terminalRef.current;
-          ptyRef.current.resize(cols, rows).catch((err) => {
-            logWorktree("warn", "Failed to resize PTY", { error: String(err) });
-          });
-        }
+    // Get actual terminal dimensions after render
+    requestAnimationFrame(() => {
+      const screen = terminalMountRef.current?.querySelector('.xterm-screen');
+      if (screen) {
+        const rect = screen.getBoundingClientRect();
+        terminalSizeRef.current = { width: rect.width, height: rect.height };
+        calculateScale();
       }
-    };
+    });
 
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(containerRef.current);
+    // Observe container for resize to recalculate scale
+    const resizeObserver = new ResizeObserver(() => {
+      calculateScale();
+    });
+
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
 
     return () => {
       resizeObserver.disconnect();
       terminal.dispose();
       terminalRef.current = null;
-      fitAddonRef.current = null;
     };
-  }, []);
+  }, [cols, rows, calculateScale]);
 
   // Start agent
   const startAgent = useCallback(async () => {
@@ -121,25 +141,20 @@ export function useTerminal({
     setStatus("starting");
     setError(null);
 
-    // Fit terminal to get accurate dimensions
-    if (fitAddonRef.current) {
-      fitAddonRef.current.fit();
-    }
-
     const terminal = terminalRef.current;
     const env: Record<string, string> = {};
     if (port !== null) {
       env.PORT = String(port);
     }
 
-    logWorktree("info", "Starting Claude agent", { worktreePath, port });
+    logWorktree("info", "Starting Claude agent", { worktreePath, port, cols, rows });
 
     const result = await spawnPty({
       cmd: "claude",
       args: [],
       cwd: worktreePath,
-      cols: terminal.cols,
-      rows: terminal.rows,
+      cols,
+      rows,
       env,
     });
 
@@ -181,7 +196,7 @@ export function useTerminal({
       disposeOnData.dispose();
       ptyRef.current = null;
     });
-  }, [worktreePath, port]);
+  }, [worktreePath, port, cols, rows]);
 
   // Stop agent
   const stopAgent = useCallback(async () => {
@@ -217,9 +232,11 @@ export function useTerminal({
 
   return {
     containerRef,
+    terminalMountRef,
     status,
     error,
     startAgent,
     stopAgent,
+    scale,
   };
 }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -24,6 +24,8 @@ export interface TerminalSettings {
   readonly postOpenCommand?: string; // e.g., "bun run dev"
   readonly autoPromptClaude?: boolean; // Auto-prompt Claude with issue context when opening terminal
   readonly claudeStartupDelay?: number; // Milliseconds to wait for Claude to initialize before pasting prompt
+  readonly terminalCols?: number;  // Fixed terminal columns for agent view (default: 80)
+  readonly terminalRows?: number;  // Fixed terminal rows for agent view (default: 24)
 }
 
 export interface AntlerConfig {
@@ -40,6 +42,8 @@ interface RawConfig {
     postOpenCommand?: unknown;
     autoPromptClaude?: unknown;
     claudeStartupDelay?: unknown;
+    terminalCols?: unknown;
+    terminalRows?: unknown;
   };
 }
 
@@ -49,6 +53,10 @@ interface RawConfig {
 
 /** Default delay (ms) to wait for Claude to initialize before pasting prompt */
 export const DEFAULT_CLAUDE_STARTUP_DELAY = 2500;
+
+/** Default terminal dimensions for agent view */
+export const DEFAULT_TERMINAL_COLS = 80;
+export const DEFAULT_TERMINAL_ROWS = 24;
 
 // ============================================================================
 // Validation
@@ -65,7 +73,7 @@ function validateTerminalSettings(terminal: unknown): TerminalSettings | undefin
     return undefined;
   }
   const t = terminal as RawConfig["terminal"];
-  const result: { app?: string; postOpenCommand?: string; autoPromptClaude?: boolean; claudeStartupDelay?: number } = {};
+  const result: { app?: string; postOpenCommand?: string; autoPromptClaude?: boolean; claudeStartupDelay?: number; terminalCols?: number; terminalRows?: number } = {};
 
   if (t?.app !== undefined && typeof t.app === "string" && t.app.trim()) {
     result.app = t.app.trim();
@@ -78,6 +86,12 @@ function validateTerminalSettings(terminal: unknown): TerminalSettings | undefin
   }
   if (t?.claudeStartupDelay !== undefined && typeof t.claudeStartupDelay === "number" && t.claudeStartupDelay >= 500 && t.claudeStartupDelay <= 10000) {
     result.claudeStartupDelay = t.claudeStartupDelay;
+  }
+  if (t?.terminalCols !== undefined && typeof t.terminalCols === "number" && t.terminalCols >= 40 && t.terminalCols <= 200) {
+    result.terminalCols = t.terminalCols;
+  }
+  if (t?.terminalRows !== undefined && typeof t.terminalRows === "number" && t.terminalRows >= 10 && t.terminalRows <= 100) {
+    result.terminalRows = t.terminalRows;
   }
 
   return Object.keys(result).length > 0 ? Object.freeze(result) : undefined;
@@ -598,4 +612,34 @@ export async function getClaudeStartupDelay(): Promise<number> {
   const delay = result.value.terminal?.claudeStartupDelay ?? DEFAULT_CLAUDE_STARTUP_DELAY;
   logConfig("debug", "Retrieved Claude startup delay setting", { delay });
   return delay;
+}
+
+/**
+ * Get the terminal columns setting for agent view
+ * Returns DEFAULT_TERMINAL_COLS if not configured
+ */
+export async function getTerminalCols(): Promise<number> {
+  const result = await getCachedConfig();
+  if (!result.ok) {
+    logConfig("debug", "Failed to get terminal cols - config unavailable");
+    return DEFAULT_TERMINAL_COLS;
+  }
+  const cols = result.value.terminal?.terminalCols ?? DEFAULT_TERMINAL_COLS;
+  logConfig("debug", "Retrieved terminal cols setting", { cols });
+  return cols;
+}
+
+/**
+ * Get the terminal rows setting for agent view
+ * Returns DEFAULT_TERMINAL_ROWS if not configured
+ */
+export async function getTerminalRows(): Promise<number> {
+  const result = await getCachedConfig();
+  if (!result.ok) {
+    logConfig("debug", "Failed to get terminal rows - config unavailable");
+    return DEFAULT_TERMINAL_ROWS;
+  }
+  const rows = result.value.terminal?.terminalRows ?? DEFAULT_TERMINAL_ROWS;
+  logConfig("debug", "Retrieved terminal rows setting", { rows });
+  return rows;
 }


### PR DESCRIPTION
## Summary

- Added fixed terminal size (default 80×24) for the Agent view to fix formatting issues with CLI tools like Claude Code
- Terminal scales down visually when container is smaller using CSS transform
- Added configurable terminal dimensions via Settings → Terminal → "Agent Terminal Dimensions"

Closes #55

## Test plan

- [ ] Open Settings → Terminal section
- [ ] Verify "Agent Terminal Dimensions" inputs appear with defaults 80×24
- [ ] Change dimensions and save
- [ ] Open Agent view with a terminal
- [ ] Verify terminal uses configured dimensions
- [ ] Resize window smaller than terminal - verify it scales smoothly
- [ ] Run Claude Code and verify formatting is correct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)