### PR TITLE
feat: Enhanced issue management with Create More and Close Issue functionality

### DIFF
--- a/src/core/types/log.ts
+++ b/src/core/types/log.ts
@@ -29,6 +29,7 @@ export type UserActionType =
   | "card_drag_end"
   | "card_opened"
   | "card_updated"
+  | "card_closed"
   | "comment_added"
   | "data_refresh"
   | "data_source_toggle"
@@ -49,6 +50,7 @@ export type UserActionType =
   | "open_terminal"
   | "settings_save"
   | "issue_created"
+  | "issue_closed"
   | "template_selected";
 
 // ============================================================================

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { AgentView } from './components/AgentView';
 import { DotBackground } from './components/DotBackground';
 import { DetailedCardView } from './components/DetailedCardView';
 import { CreateIssueDialog } from './components/CreateIssueDialog';
+import { ConfirmationDialog } from './components/ui/ConfirmationDialog';
 import { useCards } from './hooks/useCards';
 import { useDataSource } from './hooks/useDataSource';
 import { useViewToggle } from './hooks/useViewToggle';
@@ -19,8 +20,9 @@ import { NotificationProvider } from './context/NotificationContext';
 import { NotificationContainer } from './components/ui/NotificationContainer';
 import { NotificationPopover } from './components/ui/NotificationPopover';
 import { ErrorBoundary, CompactFallback } from './components/ErrorBoundary';
-import { getCachedConfig, clearConfigCache, loadConfig } from '@services/config';
-import { initLogger, shutdownLogger, logSystem, logUserAction } from '@services/logging';
+import { getCachedConfig, clearConfigCache, loadConfig, getConfirmCloseOnDragToDone } from '@services/config';
+import { closeIssue } from '@services/github';
+import { initLogger, shutdownLogger, logSystem, logUserAction, logDataSync } from '@services/logging';
 
 function ActionButton({
   onClick,
@@ -169,7 +171,7 @@ export default function App() {
   const { view, setView } = useViewToggle();
   const projectSelector = useProjectSelector();
   const { cards, setCards, isLoading, isRefreshing, error, errorCode, refresh } = useCards({ dataSource });
-  const { handleCardStatusChange } = useKanbanBoard({ cards, onCardsChange: setCards });
+  const { handleCardStatusChange, pendingClose, confirmPendingClose, cancelPendingClose } = useKanbanBoard({ cards, onCardsChange: setCards });
   const [repository, setRepository] = useState<string | null>(null);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [selectedCard, setSelectedCard] = useState<Card | null>(null);
@@ -177,6 +179,10 @@ export default function App() {
   const [showProjectSelector, setShowProjectSelector] = useState(false);
   const [isCreateIssueOpen, setIsCreateIssueOpen] = useState(false);
   const hasInitialized = useRef(false);
+
+  // State for drag-to-done close operation
+  const [isClosingFromDrag, setIsClosingFromDrag] = useState(false);
+  const [confirmCloseOnDragSetting, setConfirmCloseOnDragSetting] = useState(true);
 
   const handleCardClick = useCallback((card: Card) => {
     setSelectedCard(card);
@@ -216,6 +222,47 @@ export default function App() {
     // Refresh to get the new issue from GitHub
     await refresh();
   }, [refresh]);
+
+  // Handler when user confirms drag-to-done close (or auto-confirm if setting disabled)
+  const handleConfirmDragToDone = useCallback(async () => {
+    if (!pendingClose || !repository) return;
+
+    setIsClosingFromDrag(true);
+    const result = await closeIssue(repository, pendingClose.card.github.issueNumber!, {
+      reason: 'completed',
+    });
+    setIsClosingFromDrag(false);
+
+    if (result.ok) {
+      // Remove card from board
+      setCards((prev) => prev.filter((c) => c.sessionUid !== pendingClose.card.sessionUid));
+      confirmPendingClose();
+      logUserAction('issue_closed', 'Issue closed via drag to Done', {
+        cardId: pendingClose.card.sessionUid,
+        issueNumber: pendingClose.card.github.issueNumber,
+      });
+    } else {
+      // Revert on failure
+      cancelPendingClose();
+      logDataSync('error', 'Failed to close issue via drag to Done', {
+        cardId: pendingClose.card.sessionUid,
+        issueNumber: pendingClose.card.github.issueNumber,
+        error: result.error.message,
+      });
+    }
+  }, [pendingClose, repository, confirmPendingClose, cancelPendingClose, setCards]);
+
+  // Load confirm close setting on mount and when settings change
+  useEffect(() => {
+    getConfirmCloseOnDragToDone().then(setConfirmCloseOnDragSetting);
+  }, []);
+
+  // Auto-close if setting is disabled (skip confirmation)
+  useEffect(() => {
+    if (pendingClose && !confirmCloseOnDragSetting && !isMock) {
+      handleConfirmDragToDone();
+    }
+  }, [pendingClose, confirmCloseOnDragSetting, isMock, handleConfirmDragToDone]);
 
   // Initialize project selector and load repository config
   useEffect(() => {
@@ -328,6 +375,8 @@ export default function App() {
 
   const handleConfigChange = async () => {
     clearConfigCache();
+    // Reload confirm close setting
+    getConfirmCloseOnDragToDone().then(setConfirmCloseOnDragSetting);
     if (!isMock) {
       setCards([]);  // Clear old cards before loading new project
       // Reload from global config (project service auto-saves on project switch)
@@ -444,6 +493,19 @@ export default function App() {
           onClose={() => setShowProjectSelector(false)}
           allowClose={projectSelector.hasProject}
         />
+        {/* Confirmation dialog for drag-to-done close */}
+        {pendingClose && confirmCloseOnDragSetting && !isMock && (
+          <ConfirmationDialog
+            isOpen={true}
+            onConfirm={handleConfirmDragToDone}
+            onCancel={cancelPendingClose}
+            title="Close Issue"
+            message={`Moving "${pendingClose.card.github.title}" to Done will close the issue on GitHub. Continue?`}
+            confirmLabel="Close Issue"
+            confirmVariant="destructive"
+            isLoading={isClosingFromDrag}
+          />
+        )}
       </NotificationProvider>
     </ErrorBoundary>
   );

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -197,6 +197,12 @@ export default function App() {
     setSelectedCard(updatedCard);
   }, [setCards]);
 
+  const handleCardClose = useCallback((cardId: string) => {
+    setCards((prev) => prev.filter((card) => card.sessionUid !== cardId));
+    setSelectedCard(null);
+    logUserAction('card_closed', 'Card removed after issue closed', { cardId });
+  }, [setCards]);
+
   const handleCreateIssue = useCallback(() => {
     if (!repository) {
       logSystem('warn', 'Cannot create issue: no repository configured');
@@ -411,6 +417,7 @@ export default function App() {
             isOpen={selectedCard !== null}
             onClose={handleCloseDetailedView}
             onCardUpdate={handleCardUpdate}
+            onCardClose={!isMock ? handleCardClose : undefined}
           />
         </ErrorBoundary>
         <ErrorBoundary

--- a/src/renderer/components/CreateIssueDialog/CreateIssueDialog.tsx
+++ b/src/renderer/components/CreateIssueDialog/CreateIssueDialog.tsx
@@ -3,7 +3,7 @@
  * Modal for creating new GitHub issues with template support
  */
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
@@ -37,6 +37,7 @@ export function CreateIssueDialog({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [createMore, setCreateMore] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Fetch templates and repo metadata
   const { templates, isLoading: isLoadingTemplates } = useIssueTemplates(repo, isOpen);
@@ -64,12 +65,29 @@ export function CreateIssueDialog({
     }
   }, [isOpen, repo]);
 
-  // Clear success message when user starts editing
+  // Clear success message when user starts editing any field
   useEffect(() => {
-    if (successMessage && formState.title) {
-      setSuccessMessage(null);
+    if (successMessage) {
+      const hasContent =
+        formState.title ||
+        formState.body ||
+        formState.labels.length > 0 ||
+        formState.assignees.length > 0 ||
+        formState.milestone;
+      if (hasContent) {
+        setSuccessMessage(null);
+      }
     }
-  }, [formState.title, successMessage]);
+  }, [formState, successMessage]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) {
+        clearTimeout(successTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Handle Escape key
   useEffect(() => {
@@ -186,7 +204,10 @@ export function CreateIssueDialog({
           setSuccessMessage(`Issue #${result.value.issueNumber} created`);
 
           // Auto-dismiss success message after 3 seconds
-          setTimeout(() => setSuccessMessage(null), 3000);
+          if (successTimeoutRef.current) {
+            clearTimeout(successTimeoutRef.current);
+          }
+          successTimeoutRef.current = setTimeout(() => setSuccessMessage(null), 3000);
         } else {
           onClose();
         }

--- a/src/renderer/components/CreateIssueDialog/CreateIssueDialog.tsx
+++ b/src/renderer/components/CreateIssueDialog/CreateIssueDialog.tsx
@@ -35,6 +35,8 @@ export function CreateIssueDialog({
   const [additionalMilestones, setAdditionalMilestones] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [createMore, setCreateMore] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   // Fetch templates and repo metadata
   const { templates, isLoading: isLoadingTemplates } = useIssueTemplates(repo, isOpen);
@@ -56,10 +58,18 @@ export function CreateIssueDialog({
       setFormState(INITIAL_STATE);
       setSelectedTemplate(null);
       setSubmitError(null);
+      setSuccessMessage(null);
       setAdditionalMilestones([]);
       logUserAction("modal_open", "CreateIssueDialog opened", { repo });
     }
   }, [isOpen, repo]);
+
+  // Clear success message when user starts editing
+  useEffect(() => {
+    if (successMessage && formState.title) {
+      setSuccessMessage(null);
+    }
+  }, [formState.title, successMessage]);
 
   // Handle Escape key
   useEffect(() => {
@@ -158,6 +168,7 @@ export function CreateIssueDialog({
         logUserAction("issue_created", "New issue created", {
           issueNumber: result.value.issueNumber,
           repo,
+          createMore,
         });
         logPerformance("Issue creation completed", elapsed, {
           issueNumber: result.value.issueNumber,
@@ -166,7 +177,19 @@ export function CreateIssueDialog({
         if (result.value.issueNumber) {
           onIssueCreated(result.value.issueNumber);
         }
-        onClose();
+
+        if (createMore) {
+          // Reset form but keep dialog open
+          setFormState(INITIAL_STATE);
+          setSelectedTemplate(null);
+          setAdditionalMilestones([]);
+          setSuccessMessage(`Issue #${result.value.issueNumber} created`);
+
+          // Auto-dismiss success message after 3 seconds
+          setTimeout(() => setSuccessMessage(null), 3000);
+        } else {
+          onClose();
+        }
       } else {
         logDataSync("error", "Failed to create issue", {
           repo,
@@ -187,7 +210,7 @@ export function CreateIssueDialog({
     } finally {
       setIsSubmitting(false);
     }
-  }, [formState, repo, onIssueCreated, onClose]);
+  }, [formState, repo, onIssueCreated, onClose, createMore]);
 
   const handleCancel = useCallback(() => {
     logUserAction("modal_close", "CreateIssueDialog cancelled", { repo });
@@ -319,7 +342,23 @@ export function CreateIssueDialog({
 
         {/* Footer */}
         <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-xl">
-          <div>
+          <div className="flex items-center gap-4">
+            {/* Create more checkbox */}
+            <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={createMore}
+                onChange={(e) => setCreateMore(e.target.checked)}
+                disabled={isSubmitting}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
+              />
+              Create more
+            </label>
+
+            {/* Success/Error messages */}
+            {successMessage && (
+              <span className="text-sm text-green-600">{successMessage}</span>
+            )}
             {submitError && (
               <span className="text-sm text-red-600">{submitError}</span>
             )}

--- a/src/renderer/components/DetailedCardView/DetailedCardView.tsx
+++ b/src/renderer/components/DetailedCardView/DetailedCardView.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Button } from "../ui/button";
+import { ConfirmationDialog } from "../ui/ConfirmationDialog";
 import { DetailedCardViewHeader } from "./DetailedCardViewHeader";
 import { IssueInfoSection } from "./IssueInfoSection";
 import { MetadataSection } from "./MetadataSection";
@@ -18,6 +19,7 @@ import {
   updateIssue,
   addIssueComment,
   createMilestone,
+  closeIssue,
 } from "@services/github";
 import { logUserAction, logDataSync, logPerformance } from "@services/logging";
 import { useRepoMetadata } from "./hooks";
@@ -43,12 +45,16 @@ export function DetailedCardView({
   isOpen,
   onClose,
   onCardUpdate,
+  onCardClose,
 }: DetailedCardViewProps) {
   const [editState, setEditState] = useState<EditState | null>(null);
   const [additionalMilestones, setAdditionalMilestones] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [isAddingComment, setIsAddingComment] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [closeError, setCloseError] = useState<string | null>(null);
   const wasOpenRef = useRef(false);
 
   // Compute repo string for metadata fetching
@@ -283,6 +289,53 @@ export function DetailedCardView({
     onClose();
   }, [onClose]);
 
+  const handleOpenCloseConfirm = useCallback(() => {
+    setIsCloseConfirmOpen(true);
+  }, []);
+
+  const handleCancelClose = useCallback(() => {
+    setIsCloseConfirmOpen(false);
+  }, []);
+
+  const handleConfirmClose = useCallback(async () => {
+    if (!card || !card.github.issueNumber || !onCardClose) return;
+
+    setIsClosing(true);
+    setCloseError(null);
+
+    const repoPath = `${card.github.repoOwner}/${card.github.repoName}`;
+
+    try {
+      const result = await closeIssue(repoPath, card.github.issueNumber, {
+        reason: "completed",
+      });
+
+      if (result.ok) {
+        logUserAction("issue_closed", "Issue closed via DetailedCardView", {
+          cardId: card.sessionUid,
+          issueNumber: card.github.issueNumber,
+        });
+        setIsCloseConfirmOpen(false);
+        onCardClose(card.sessionUid);
+      } else {
+        logDataSync("error", "Failed to close issue", {
+          issueNumber: card.github.issueNumber,
+          error: result.error.message,
+        });
+        setCloseError(result.error.message);
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logDataSync("error", "Exception while closing issue", {
+        issueNumber: card.github.issueNumber,
+        error: errorMessage,
+      });
+      setCloseError(errorMessage);
+    } finally {
+      setIsClosing(false);
+    }
+  }, [card, onCardClose]);
+
   if (!isOpen || !card) {
     return null;
   }
@@ -361,21 +414,41 @@ export function DetailedCardView({
 
         {/* Footer */}
         <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-xl">
-          <div>
-            {saveError && (
-              <span className="text-sm text-red-600">{saveError}</span>
+          <div className="flex items-center gap-2">
+            {onCardClose && card.github.state === "open" && (
+              <Button
+                variant="destructive"
+                onClick={handleOpenCloseConfirm}
+                disabled={isSaving || isClosing}
+              >
+                Close Issue
+              </Button>
+            )}
+            {(saveError || closeError) && (
+              <span className="text-sm text-red-600">{saveError || closeError}</span>
             )}
           </div>
           <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
+            <Button variant="outline" onClick={handleCancel} disabled={isSaving || isClosing}>
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={!isDirty || isSaving}>
+            <Button onClick={handleSave} disabled={!isDirty || isSaving || isClosing}>
               {isSaving ? "Saving..." : "Save Changes"}
             </Button>
           </div>
         </div>
       </div>
+
+      <ConfirmationDialog
+        isOpen={isCloseConfirmOpen}
+        onConfirm={handleConfirmClose}
+        onCancel={handleCancelClose}
+        title="Close Issue"
+        message={`Are you sure you want to close "${card.github.title}"? This will mark the issue as completed on GitHub and remove it from the board.`}
+        confirmLabel="Close Issue"
+        confirmVariant="destructive"
+        isLoading={isClosing}
+      />
     </div>
   );
 }

--- a/src/renderer/components/DetailedCardView/types.ts
+++ b/src/renderer/components/DetailedCardView/types.ts
@@ -10,6 +10,7 @@ export interface DetailedCardViewProps {
   isOpen: boolean;
   onClose: () => void;
   onCardUpdate: (updatedCard: Card) => void;
+  onCardClose?: (cardId: string) => void;
 }
 
 export interface EditState {

--- a/src/renderer/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel/SettingsPanel.tsx
@@ -131,6 +131,7 @@ export function SettingsPanel({ isOpen, onClose, onConfigChange }: SettingsPanel
               postOpenCommand={settings.postOpenCommand}
               autoPromptClaude={settings.autoPromptClaude}
               claudeStartupDelay={settings.claudeStartupDelay}
+              confirmCloseOnDragToDone={settings.confirmCloseOnDragToDone}
               onSave={settings.saveTerminalSettings}
             />
           </SettingsGroup>

--- a/src/renderer/components/SettingsPanel/TerminalSettingsSection.tsx
+++ b/src/renderer/components/SettingsPanel/TerminalSettingsSection.tsx
@@ -13,7 +13,8 @@ interface TerminalSettingsSectionProps {
   postOpenCommand: string | null;
   autoPromptClaude: boolean | null;
   claudeStartupDelay: number | null;
-  onSave: (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number) => Promise<void>;
+  confirmCloseOnDragToDone: boolean | null;
+  onSave: (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number, confirmCloseOnDragToDone: boolean) => Promise<void>;
 }
 
 export function TerminalSettingsSection({
@@ -21,12 +22,14 @@ export function TerminalSettingsSection({
   postOpenCommand,
   autoPromptClaude: autoPromptClaudeProp,
   claudeStartupDelay: claudeStartupDelayProp,
+  confirmCloseOnDragToDone: confirmCloseOnDragToDoneProp,
   onSave,
 }: TerminalSettingsSectionProps) {
   const [app, setApp] = useState("");
   const [command, setCommand] = useState("");
   const [autoPromptClaude, setAutoPromptClaude] = useState(false);
   const [claudeStartupDelay, setClaudeStartupDelay] = useState(DEFAULT_CLAUDE_STARTUP_DELAY);
+  const [confirmCloseOnDragToDone, setConfirmCloseOnDragToDone] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
@@ -36,13 +39,15 @@ export function TerminalSettingsSection({
     setCommand(postOpenCommand ?? "");
     setAutoPromptClaude(autoPromptClaudeProp ?? false);
     setClaudeStartupDelay(claudeStartupDelayProp ?? DEFAULT_CLAUDE_STARTUP_DELAY);
-  }, [terminalApp, postOpenCommand, autoPromptClaudeProp, claudeStartupDelayProp]);
+    setConfirmCloseOnDragToDone(confirmCloseOnDragToDoneProp ?? true);
+  }, [terminalApp, postOpenCommand, autoPromptClaudeProp, claudeStartupDelayProp, confirmCloseOnDragToDoneProp]);
 
   const hasChanges =
     app !== (terminalApp ?? "") ||
     command !== (postOpenCommand ?? "") ||
     autoPromptClaude !== (autoPromptClaudeProp ?? false) ||
-    claudeStartupDelay !== (claudeStartupDelayProp ?? DEFAULT_CLAUDE_STARTUP_DELAY);
+    claudeStartupDelay !== (claudeStartupDelayProp ?? DEFAULT_CLAUDE_STARTUP_DELAY) ||
+    confirmCloseOnDragToDone !== (confirmCloseOnDragToDoneProp ?? true);
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -53,16 +58,18 @@ export function TerminalSettingsSection({
       hasCommand: Boolean(command),
       autoPromptClaude,
       claudeStartupDelay,
+      confirmCloseOnDragToDone,
     });
 
     try {
-      await onSave(app, command, autoPromptClaude, claudeStartupDelay);
+      await onSave(app, command, autoPromptClaude, claudeStartupDelay, confirmCloseOnDragToDone);
       setSaveSuccess(true);
       logUserAction("settings_save", "Terminal settings saved successfully", {
         app: app || "(default)",
         hasCommand: Boolean(command),
         autoPromptClaude,
         claudeStartupDelay,
+        confirmCloseOnDragToDone,
       });
       setTimeout(() => setSaveSuccess(false), 2000);
     } catch (e) {
@@ -188,6 +195,31 @@ export function TerminalSettingsSection({
           </p>
         </div>
       )}
+
+      {/* Confirm Close on Drag to Done Checkbox */}
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-2">
+          <input
+            id="confirm-close-on-drag"
+            type="checkbox"
+            checked={confirmCloseOnDragToDone}
+            onChange={(e) => {
+              setConfirmCloseOnDragToDone(e.target.checked);
+              setSaveSuccess(false);
+            }}
+            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          />
+          <label
+            htmlFor="confirm-close-on-drag"
+            className="text-sm font-medium text-gray-700"
+          >
+            Confirm before closing issues
+          </label>
+        </div>
+        <p className="text-xs text-gray-500 ml-6">
+          Show confirmation dialog when dragging cards to Done column
+        </p>
+      </div>
 
       {/* Save Button */}
       <div className="flex justify-end">

--- a/src/renderer/components/ui/ConfirmationDialog.tsx
+++ b/src/renderer/components/ui/ConfirmationDialog.tsx
@@ -1,0 +1,73 @@
+/**
+ * ConfirmationDialog Component
+ * A reusable modal dialog for confirming destructive actions
+ */
+
+import { useEffect, useCallback } from "react";
+import { Button } from "./button";
+
+export interface ConfirmationDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmVariant?: "default" | "destructive";
+  isLoading?: boolean;
+}
+
+export function ConfirmationDialog({
+  isOpen,
+  onConfirm,
+  onCancel,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  confirmVariant = "destructive",
+  isLoading = false,
+}: ConfirmationDialogProps) {
+  // Handle Escape key
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isLoading) {
+        onCancel();
+      }
+    },
+    [onCancel, isLoading]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-60 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md bg-white rounded-lg shadow-xl p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">{title}</h2>
+        <p className="text-gray-600 mb-6">{message}</p>
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" onClick={onCancel} disabled={isLoading}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={confirmVariant}
+            onClick={onConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? "Loading..." : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/ui/ConfirmationDialog.tsx
+++ b/src/renderer/components/ui/ConfirmationDialog.tsx
@@ -51,7 +51,7 @@ export function ConfirmationDialog({
   }
 
   return (
-    <div className="fixed inset-0 z-60 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50">
       <div className="w-full max-w-md bg-white rounded-lg shadow-xl p-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-2">{title}</h2>
         <p className="text-gray-600 mb-6">{message}</p>

--- a/src/renderer/hooks/useKanbanBoard.ts
+++ b/src/renderer/hooks/useKanbanBoard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { Card, CardStatus } from '@core/types/card';
 import {
   setStatus,
@@ -19,13 +19,24 @@ interface UseKanbanBoardOptions {
   onCardsChange: React.Dispatch<React.SetStateAction<Card[]>>;
 }
 
+export interface PendingCloseOperation {
+  card: Card;
+  previousStatus: CardStatus;
+}
+
 interface UseKanbanBoardReturn {
   handleCardStatusChange: (cardId: string, newStatus: CardStatus) => void;
+  pendingClose: PendingCloseOperation | null;
+  confirmPendingClose: () => void;
+  cancelPendingClose: () => void;
 }
 
 export function useKanbanBoard({ cards, onCardsChange }: UseKanbanBoardOptions): UseKanbanBoardReturn {
   // Track AbortControllers per card for cancellation support
   const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  // State for pending drag-to-done close operations
+  const [pendingClose, setPendingClose] = useState<PendingCloseOperation | null>(null);
 
   // Helper to update a single card in the cards array
   const updateCard = useCallback(
@@ -239,6 +250,7 @@ export function useKanbanBoard({ cards, onCardsChange }: UseKanbanBoardOptions):
       // Check if this is a transition that triggers work session operations
       const isIdleToInProgress = oldStatus === 'idle' && newStatus === 'in_progress';
       const isInProgressToIdle = oldStatus === 'in_progress' && newStatus === 'idle';
+      const isDragToDone = newStatus === 'done' && card.github.state === 'open' && card.github.issueNumber !== null;
 
       // For work session operations, don't update status immediately
       // The async handlers will update the status after completion
@@ -248,6 +260,21 @@ export function useKanbanBoard({ cards, onCardsChange }: UseKanbanBoardOptions):
       } else if (isInProgressToIdle) {
         // Stop work session (async) - status change handled in callback
         handleStopWorkSession(card);
+      } else if (isDragToDone) {
+        // Dragging an open issue to Done - store pending close operation
+        // App.tsx will handle confirmation and close the issue
+        setPendingClose({ card, previousStatus: oldStatus });
+
+        // Optimistically move card to Done
+        onCardsChange((prevCards) =>
+          prevCards.map((c) => {
+            if (c.sessionUid !== cardId) return c;
+            if (c.hasError) {
+              return setStatus(clearError(c), 'done');
+            }
+            return setStatus(c, 'done');
+          })
+        );
       } else {
         // For other status changes (e.g., moving between waiting/done), update immediately
         onCardsChange((prevCards) =>
@@ -272,5 +299,24 @@ export function useKanbanBoard({ cards, onCardsChange }: UseKanbanBoardOptions):
     [cards, onCardsChange, handleStartWorkSession, handleStopWorkSession]
   );
 
-  return { handleCardStatusChange };
+  // Confirm the pending close operation (called after successful close)
+  const confirmPendingClose = useCallback(() => {
+    setPendingClose(null);
+  }, []);
+
+  // Cancel the pending close operation (revert card to original status)
+  const cancelPendingClose = useCallback(() => {
+    if (pendingClose) {
+      onCardsChange((prevCards) =>
+        prevCards.map((c) =>
+          c.sessionUid === pendingClose.card.sessionUid
+            ? setStatus(c, pendingClose.previousStatus)
+            : c
+        )
+      );
+      setPendingClose(null);
+    }
+  }, [pendingClose, onCardsChange]);
+
+  return { handleCardStatusChange, pendingClose, confirmPendingClose, cancelPendingClose };
 }

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -17,6 +17,7 @@ import {
   getPostOpenCommand,
   getAutoPromptClaude,
   getClaudeStartupDelay,
+  getConfirmCloseOnDragToDone,
   DEFAULT_CLAUDE_STARTUP_DELAY,
 } from "@services/config";
 import { checkGitHubAuth } from "@services/github";
@@ -42,6 +43,7 @@ interface SettingsState {
   postOpenCommand: string | null;
   autoPromptClaude: boolean | null;
   claudeStartupDelay: number | null;
+  confirmCloseOnDragToDone: boolean | null;
 }
 
 export function useSettings() {
@@ -60,6 +62,7 @@ export function useSettings() {
     postOpenCommand: null,
     autoPromptClaude: null,
     claudeStartupDelay: null,
+    confirmCloseOnDragToDone: null,
   });
 
   const checkConfig = useCallback(async () => {
@@ -147,11 +150,12 @@ export function useSettings() {
 
   const loadTerminalSettings = useCallback(async () => {
     logConfig("debug", "Loading terminal settings");
-    const [app, command, autoPrompt, startupDelay] = await Promise.all([
+    const [app, command, autoPrompt, startupDelay, confirmClose] = await Promise.all([
       getTerminalApp(),
       getPostOpenCommand(),
       getAutoPromptClaude(),
       getClaudeStartupDelay(),
+      getConfirmCloseOnDragToDone(),
     ]);
     setState((prev) => ({
       ...prev,
@@ -159,23 +163,24 @@ export function useSettings() {
       postOpenCommand: command,
       autoPromptClaude: autoPrompt,
       claudeStartupDelay: startupDelay,
+      confirmCloseOnDragToDone: confirmClose,
     }));
-    logConfig("debug", "Terminal settings loaded", { app, command, autoPromptClaude: autoPrompt, claudeStartupDelay: startupDelay });
+    logConfig("debug", "Terminal settings loaded", { app, command, autoPromptClaude: autoPrompt, claudeStartupDelay: startupDelay, confirmCloseOnDragToDone: confirmClose });
   }, []);
 
-  const saveTerminalSettings = useCallback(async (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number): Promise<void> => {
-    logConfig("info", "Saving terminal settings", { app, command, autoPromptClaude, claudeStartupDelay });
+  const saveTerminalSettings = useCallback(async (app: string, command: string, autoPromptClaude: boolean, claudeStartupDelay: number, confirmCloseOnDragToDone: boolean): Promise<void> => {
+    logConfig("info", "Saving terminal settings", { app, command, autoPromptClaude, claudeStartupDelay, confirmCloseOnDragToDone });
 
     // Load current config content and update it
     const contentResult = await getConfigContent();
     if (!contentResult.ok) {
       // Create new config with terminal settings
       logConfig("debug", "Config file does not exist, creating new config");
-      const hasTerminalSettings = app || command || autoPromptClaude;
+      const hasTerminalSettings = app || command || autoPromptClaude || !confirmCloseOnDragToDone;
       const newContent = `github:
   repository: ""
 ${hasTerminalSettings ? `terminal:
-${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n` : ""}${autoPromptClaude ? `  autoPromptClaude: true\n` : ""}${autoPromptClaude && claudeStartupDelay !== DEFAULT_CLAUDE_STARTUP_DELAY ? `  claudeStartupDelay: ${claudeStartupDelay}\n` : ""}` : ""}`;
+${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n` : ""}${autoPromptClaude ? `  autoPromptClaude: true\n` : ""}${autoPromptClaude && claudeStartupDelay !== DEFAULT_CLAUDE_STARTUP_DELAY ? `  claudeStartupDelay: ${claudeStartupDelay}\n` : ""}${!confirmCloseOnDragToDone ? `  confirmCloseOnDragToDone: false\n` : ""}` : ""}`;
       await saveConfigContent(newContent);
     } else {
       // Parse and update existing config
@@ -185,7 +190,8 @@ ${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n`
         const parsed = load(contentResult.value) as Record<string, unknown>;
 
         // Update terminal section
-        const hasTerminalSettings = app || command || autoPromptClaude;
+        // Only save confirmCloseOnDragToDone if it's false (non-default)
+        const hasTerminalSettings = app || command || autoPromptClaude || !confirmCloseOnDragToDone;
         if (hasTerminalSettings) {
           parsed.terminal = {
             ...(app && { app }),
@@ -193,6 +199,8 @@ ${app ? `  app: "${app}"\n` : ""}${command ? `  postOpenCommand: "${command}"\n`
             ...(autoPromptClaude && { autoPromptClaude }),
             // Only save delay if auto-prompt is enabled and it's not the default
             ...(autoPromptClaude && claudeStartupDelay !== DEFAULT_CLAUDE_STARTUP_DELAY && { claudeStartupDelay }),
+            // Only save confirmCloseOnDragToDone if it's false (non-default)
+            ...(!confirmCloseOnDragToDone && { confirmCloseOnDragToDone: false }),
           };
         } else {
           delete parsed.terminal;

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -24,6 +24,7 @@ export interface TerminalSettings {
   readonly postOpenCommand?: string; // e.g., "bun run dev"
   readonly autoPromptClaude?: boolean; // Auto-prompt Claude with issue context when opening terminal
   readonly claudeStartupDelay?: number; // Milliseconds to wait for Claude to initialize before pasting prompt
+  readonly confirmCloseOnDragToDone?: boolean; // Show confirmation dialog when dragging to Done (default true)
 }
 
 export interface AntlerConfig {
@@ -40,6 +41,7 @@ interface RawConfig {
     postOpenCommand?: unknown;
     autoPromptClaude?: unknown;
     claudeStartupDelay?: unknown;
+    confirmCloseOnDragToDone?: unknown;
   };
 }
 
@@ -65,7 +67,7 @@ function validateTerminalSettings(terminal: unknown): TerminalSettings | undefin
     return undefined;
   }
   const t = terminal as RawConfig["terminal"];
-  const result: { app?: string; postOpenCommand?: string; autoPromptClaude?: boolean; claudeStartupDelay?: number } = {};
+  const result: { app?: string; postOpenCommand?: string; autoPromptClaude?: boolean; claudeStartupDelay?: number; confirmCloseOnDragToDone?: boolean } = {};
 
   if (t?.app !== undefined && typeof t.app === "string" && t.app.trim()) {
     result.app = t.app.trim();
@@ -78,6 +80,9 @@ function validateTerminalSettings(terminal: unknown): TerminalSettings | undefin
   }
   if (t?.claudeStartupDelay !== undefined && typeof t.claudeStartupDelay === "number" && t.claudeStartupDelay >= 500 && t.claudeStartupDelay <= 10000) {
     result.claudeStartupDelay = t.claudeStartupDelay;
+  }
+  if (t?.confirmCloseOnDragToDone !== undefined && typeof t.confirmCloseOnDragToDone === "boolean") {
+    result.confirmCloseOnDragToDone = t.confirmCloseOnDragToDone;
   }
 
   return Object.keys(result).length > 0 ? Object.freeze(result) : undefined;
@@ -598,4 +603,20 @@ export async function getClaudeStartupDelay(): Promise<number> {
   const delay = result.value.terminal?.claudeStartupDelay ?? DEFAULT_CLAUDE_STARTUP_DELAY;
   logConfig("debug", "Retrieved Claude startup delay setting", { delay });
   return delay;
+}
+
+/**
+ * Get the confirm close on drag to Done setting
+ * When enabled, shows a confirmation dialog when dragging cards to the Done column
+ * Returns true (enabled) by default
+ */
+export async function getConfirmCloseOnDragToDone(): Promise<boolean> {
+  const result = await getCachedConfig();
+  if (!result.ok) {
+    logConfig("debug", "Failed to get confirm close on drag to Done - config unavailable");
+    return true;
+  }
+  const confirm = result.value.terminal?.confirmCloseOnDragToDone ?? true;
+  logConfig("debug", "Retrieved confirm close on drag to Done setting", { confirm });
+  return confirm;
 }

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -560,6 +560,38 @@ export async function addIssueComment(
   return ok(undefined);
 }
 
+export interface CloseIssueOptions {
+  comment?: string;
+  reason?: "completed" | "not_planned";
+}
+
+/**
+ * Close an issue
+ * Uses gh issue close command
+ */
+export async function closeIssue(
+  repo: string,
+  issueNumber: number,
+  options: CloseIssueOptions = {}
+): Promise<GitHubResult<void>> {
+  const args = ["issue", "close", String(issueNumber), "--repo", repo];
+
+  if (options.comment) {
+    args.push("--comment", options.comment);
+  }
+  if (options.reason) {
+    args.push("--reason", options.reason);
+  }
+
+  logDataSync("info", "Closing issue", { repo, issueNumber });
+
+  const result = await execGh(args);
+  if (!result.ok) return result;
+
+  logDataSync("info", "Issue closed", { repo, issueNumber });
+  return ok(undefined);
+}
+
 // ============================================================================
 // Repository Metadata Fetching
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Create More toggle**: After creating an issue, optionally stay in the dialog to create another issue immediately
- **Success message improvements**: Show success feedback with issue number after creation, auto-clear timeout management
- **Close Issue from DetailedCardView**: Add button to close issues directly from the card details modal
- **Auto-close on drag to Done**: Dragging an open issue to the Done column prompts to close it on GitHub
- **Confirmation setting**: New "Confirm before closing issues" setting to control the drag-to-Done confirmation dialog

Closes #56

## Test plan

- [ ] Create a new issue, verify success message appears
- [ ] Toggle "Create more" on, create issue, verify dialog stays open with fields cleared
- [ ] Open card details, click "Close Issue", verify confirmation and issue closes
- [ ] Drag an open issue card to Done column, verify confirmation dialog appears
- [ ] Cancel the confirmation, verify card reverts to original column
- [ ] Confirm close, verify issue closes on GitHub and card is removed
- [ ] Disable "Confirm before closing issues" in settings, drag to Done, verify auto-close without dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)